### PR TITLE
Use CircleCI to deploy monolith to Heroku and run tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,7 @@ machine:
     HACKBOT_ADMINS: fake,admin,list
     STREAK_DEMO_USER_BOX_KEY: fake_streak_key
     GITHUB_BOT_ACCESS_TOKEN: fake_access_token
+
     DATABASE_URL: postgresql://ubuntu:@127.0.0.1:5432/circle_test
 dependencies:
   override:


### PR DESCRIPTION
Closes #1
Closes #2 