### PR TITLE
Include submodules in deploys

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,123 @@
+#!/bin/sh
+#
+# must be run from repository root. deploys api/ and frontend/ to heroku.
+#
+# couple notes:
+#
+# - since this creates history for any subdirectories that have submodules in
+#   them, this'll create new deployments on every run because it does a force
+#   push
+# - submodules must be initialized for this script to work
+
+giant_notice() {
+  local text="$1"
+
+  local text_len=${#text}
+  
+  local hr=$(printf "%-${text_len}s" "=" | sed 's/ /=/g')
+
+  cat <<EOF
+
+${hr}
+${text}
+${hr}
+
+EOF
+}
+
+# override to supress output
+pushd() {
+  command pushd "$@" > /dev/null
+}
+
+# override to supress output
+popd() {
+  command popd "$@" > /dev/null
+}
+
+list_submodules() {
+  # from https://stackoverflow.com/a/17157444
+  grep path .gitmodules | sed 's/.*= //'
+}
+
+get_submodule_path() {
+  local submodule_name="$1"
+
+  git config --file .gitmodules --get "submodule.${submodule_name}.path"
+}
+
+get_submodule_url() {
+  local submodule_name="$1"
+
+  git config --file .gitmodules --get "submodule.${submodule_name}.url"
+}
+
+# must include trailing slash for dir (ex. "frontend/", not "frontend"). also do
+# "frontend/", not "./frontend/".
+deploy_dir() {
+  local dir="$1"
+  local remote="$2"
+  local ref="$3"
+
+  # init submodules in case they aren't already initialized
+  git submodule init && git submodule update
+
+  # set up local dir to push to
+  local tmp_bare="$(mktemp -d)"
+
+  git init --bare "$tmp_bare"
+
+  # push subtree
+  git subtree push --prefix "$dir" "$tmp_bare" "$ref"
+
+  #
+  # pull from the local dir into temp project, generate .gitmodules, push to
+  # remote
+  #
+
+  local tmp_proj="$(mktemp -d)"
+
+  git clone "$tmp_bare" "$tmp_proj"
+
+  for submodule in $( list_submodules | grep "$dir" ); do
+    local submodule_path=$(get_submodule_path "$submodule")
+    local submodule_url=$(get_submodule_url "$submodule")
+
+    # remove $dir from the beginning of the submodule's path. see
+    # https://stackoverflow.com/a/16623897.
+    local resolved_path=${submodule_path#"$dir"}
+
+    pushd "$tmp_proj"
+
+    # generate .gitmodules for the subtree
+    cat <<EOT >> .gitmodules
+[submodule "${submodule}"]
+	path = ${resolved_path}
+	url = ${submodule_url}
+EOT
+
+    git add .gitmodules
+    git commit -m "Add ${submodule} to .gitmodules"
+
+    popd
+  done
+
+  pushd "${tmp_proj}"
+
+  # unfortunately must use force because we write new history each time we
+  # generate .gitmodules
+  git push "$remote" "$ref" --force 
+
+  popd
+
+  # clean up everything
+  rm -rf "$tmp_bare"
+  rm -rf "$tmp_proj"
+}
+
+giant_notice "Deploying API"
+deploy_dir "api/" "git@heroku.com:api-hackclub.git" "master"
+heroku run rake db:migrate --app api-hackclub
+
+giant_notice "Deploying Frontend"
+deploy_dir "frontend/" "git@heroku.com:frontend-hackclub.git" "master"

--- a/bin/deploy
+++ b/bin/deploy
@@ -14,6 +14,7 @@ giant_notice() {
 
   local text_len=${#text}
   
+  # see https://stackoverflow.com/a/5799353
   local hr=$(printf "%-${text_len}s" "=" | sed 's/ /=/g')
 
   cat <<EOF

--- a/bin/deploy
+++ b/bin/deploy
@@ -80,7 +80,7 @@ deploy_dir() {
 
   git clone "$tmp_bare" "$tmp_proj"
 
-  for submodule in $( list_submodules | grep "$dir" ); do
+  for submodule in $( list_submodules | grep "^${dir}" ); do
     local submodule_path=$(get_submodule_path "$submodule")
     local submodule_url=$(get_submodule_url "$submodule")
 

--- a/circle.yml
+++ b/circle.yml
@@ -48,11 +48,5 @@ deployment:
       # CircleCI shallow clones by default. This fetches the remainder of the
       # repo's history. Heroku deploys will occasionally fail without this.
       - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
-      - git subtree push --prefix frontend git@heroku.com:frontend-hackclub.git master
-      - git submodule init
-      - git submodule update --depth 1
-      - git add --all
-      - git commit -m "CircleCI autocommit to add submodule files"
-      - git subtree push --prefix api git@heroku.com:api-hackclub.git master
-      - heroku run rake db:migrate --app api-hackclub:
-          timeout: 400 # Deploys may take a long time
+      - ./bin/deploy:
+          timeout: 600 # Deploys may take a long time


### PR DESCRIPTION
This pull request introduces `bin/deploy`, a script that pushes the `api/` and `frontend/` subtrees to Heroku while preserving submodules. It does this through generating `.gitmodules` files in the relevant subtrees before making the final push to Heroku.