### PR TITLE
Revoking Hackbot from a team no longer raises errors

### DIFF
--- a/api/app/jobs/update_hackbot_slack_username_job.rb
+++ b/api/app/jobs/update_hackbot_slack_username_job.rb
@@ -6,7 +6,10 @@ class UpdateHackbotSlackUsernameJob < ApplicationJob
       info = ::SlackClient::Users.info(team.bot_user_id, team.bot_access_token)
 
       # https://api.slack.com/methods/users.info
-      unless info[:error] == 'account_inactive'
+      if info[:error] == 'account_inactive'
+        logger.info("Slack returned 'account_inactive' in team " \
+                    "'#{team.team_name}'")
+      else
         team.update(bot_username: info[:user][:name])
       end
     end

--- a/api/app/jobs/update_hackbot_slack_username_job.rb
+++ b/api/app/jobs/update_hackbot_slack_username_job.rb
@@ -4,7 +4,11 @@ class UpdateHackbotSlackUsernameJob < ApplicationJob
   def perform(*)
     Hackbot::Team.find_each do |team|
       info = ::SlackClient::Users.info(team.bot_user_id, team.bot_access_token)
-      team.update(bot_username: info[:user][:name])
+
+      # https://api.slack.com/methods/users.info
+      unless info[:error] == 'account_inactive'
+        team.update(bot_username: info[:user][:name])
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes a problem where Hackbot doesn't stop crying after the other kids
kick it out of their playground.