### PR TITLE
Use base URL from config

### DIFF
--- a/frontend/src/containers/WorkshopWrapper/WorkshopWrapper.js
+++ b/frontend/src/containers/WorkshopWrapper/WorkshopWrapper.js
@@ -3,13 +3,14 @@ import Radium from 'radium'
 import Helmet from 'react-helmet'
 import Axios from 'axios'
 
+import config from '../../config'
 import { mediaQueries } from '../../styles/common'
 import { NavBar, LoadingSpinner } from '../../components'
 import { NotFound } from '../../containers'
 
 import Workshop from './Workshop/Workshop'
 
-const baseUrl = 'https://api.hackclub.com/v1/workshops/'
+const baseUrl = config.apiBaseUrl + '/v1/workshops/'
 
 const styles = {
   wrapper: {


### PR DESCRIPTION
Use the base URL specified in the configuration file instead of hardcoding it.