### PR TITLE
Don't sync year

### DIFF
--- a/api/app/models/club_application.rb
+++ b/api/app/models/club_application.rb
@@ -94,7 +94,7 @@ class ClubApplication < ApplicationRecord
   streak_read_only spam: '1021'
 
   validates :first_name, :last_name, :email, :high_school,
-            :interesting_project, :systems_hacked, :steps_taken, :year,
+            :interesting_project, :systems_hacked, :steps_taken,
             :referer, presence: true
 
   def full_name


### PR DESCRIPTION
For some reason, the `year` attribute was not properly synced to Streak.

For the sake of getting things done NOW I'm going to put off fixing this until tomorrow. 