### PR TITLE
Add legacy_year

### DIFF
--- a/api/app/models/club_application.rb
+++ b/api/app/models/club_application.rb
@@ -88,13 +88,14 @@ class ClubApplication < ApplicationRecord
         'Matthew Email Campaign' => '9020',
         'Github Outreach—Hackathon Participant' => '9021'
       }
-    }
+    },
+    legacy_year: '1023'
   )
 
   streak_read_only spam: '1021'
 
   validates :first_name, :last_name, :email, :high_school,
-            :interesting_project, :systems_hacked, :steps_taken, :year,
+            :interesting_project, :systems_hacked, :steps_taken,
             :referer, presence: true
 
   def full_name

--- a/api/db/migrate/20170724093659_add_legacy_year_to_club_application.rb
+++ b/api/db/migrate/20170724093659_add_legacy_year_to_club_application.rb
@@ -1,0 +1,5 @@
+class AddLegacyYearToClubApplication < ActiveRecord::Migration[5.0]
+  def change
+    add_column :club_applications, :legacy_year, :string
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170720011210) do
+ActiveRecord::Schema.define(version: 20170724093659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20170720011210) do
     t.string   "notes"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
+    t.string   "legacy_year"
   end
 
   create_table "clubs", force: :cascade do |t|


### PR DESCRIPTION
Because of the two different ways which we've been denoting years in the old and new database, it's practically impossible to accurately merge the two together.

In the future, if we figure out a clean way to merge these two columns then we should. But for now I'd rather not arbitrarily lose data.