### PR TITLE
Fix application notification email format

### DIFF
--- a/api/app/mailers/club_application_mailer.rb
+++ b/api/app/mailers/club_application_mailer.rb
@@ -16,6 +16,10 @@ class ClubApplicationMailer < ApplicationMailer
     to = Mail::Address.new 'team@hackclub.com'
     to.display_name = 'Hack Club Team'
 
-    mail(to: to.format, subject: @application.high_school)
+    subject = "Hack Club Application (#{@application.full_name}, "\
+      "#{@application.high_school})"
+
+    mail(to: to.format, reply_to: @application.mail_address.format,
+         subject: subject)
   end
 end

--- a/api/app/models/club_application.rb
+++ b/api/app/models/club_application.rb
@@ -8,6 +8,20 @@ class ClubApplication < ApplicationRecord
 
   streak_default_field_mappings key: :streak_key, name: :high_school,
                                 notes: :notes, stage: :stage_key
+
+  YEARS = {
+    '2016' => '9007',
+    '2017' => '9006',
+    '2018' => '9005',
+    '2019' => '9004',
+    '2020' => '9003',
+    '2021' => '9002',
+    '2022' => '9001',
+    'Graduated' => '9008',
+    'Teacher' => '9009',
+    'Unknown' => '9010'
+  }
+
   streak_field_mappings(
     first_name: '1010',
     last_name: '1011',
@@ -22,18 +36,7 @@ class ClubApplication < ApplicationRecord
     year: {
       key: '1020',
       type: 'DROPDOWN',
-      options: {
-        '2016' => '9007',
-        '2017' => '9006',
-        '2018' => '9005',
-        '2019' => '9004',
-        '2020' => '9003',
-        '2021' => '9002',
-        '2022' => '9001',
-        'Graduated' => '9008',
-        'Teacher' => '9009',
-        'Unknown' => '9010'
-      }
+      options: YEARS,
     },
     application_quality: {
       key: '1009',
@@ -107,6 +110,18 @@ class ClubApplication < ApplicationRecord
 
   def spam?
     ClubApplicationSpamService.new.spam? self
+  end
+
+  def mail_address
+    expected = Mail::Address.new email
+    expected.display_name = full_name
+
+    expected
+  end
+
+  # Convert the Streak key into a human readable string, conversions as defined in pretty_year.
+  def pretty_year
+    YEARS.select {|_, v| v == year }.first[0]
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/api/app/models/club_application.rb
+++ b/api/app/models/club_application.rb
@@ -20,7 +20,7 @@ class ClubApplication < ApplicationRecord
     'Graduated' => '9008',
     'Teacher' => '9009',
     'Unknown' => '9010'
-  }
+  }.freeze
 
   streak_field_mappings(
     first_name: '1010',
@@ -36,7 +36,7 @@ class ClubApplication < ApplicationRecord
     year: {
       key: '1020',
       type: 'DROPDOWN',
-      options: YEARS,
+      options: YEARS
     },
     application_quality: {
       key: '1009',
@@ -119,9 +119,10 @@ class ClubApplication < ApplicationRecord
     expected
   end
 
-  # Convert the Streak key into a human readable string, conversions as defined in pretty_year.
+  # Convert the Streak key into a human readable string, conversions as
+  # defined in pretty_year.
   def pretty_year
-    YEARS.select {|_, v| v == year }.first[0]
+    YEARS.select { |_, v| v == year }.first[0]
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/api/app/views/club_application/_club_application.text.erb
+++ b/api/app/views/club_application/_club_application.text.erb
@@ -1,6 +1,6 @@
 Name: <%= @application.full_name %>
 High school: <%= @application.high_school %>
-Year: <%= @application.year %>
+Graduation year: <%= @application.pretty_year %>
 Email: <%= @application.email %>
 Phone number: <%= @application.phone_number %>
 GitHub: <%= @application.github %>

--- a/api/app/views/club_application_mailer/admin_notification.text.erb
+++ b/api/app/views/club_application_mailer/admin_notification.text.erb
@@ -3,5 +3,7 @@ New application for Hack Club received:
 <%= render "club_application/club_application" %>
 
 <% if @application.spam? %>
-    This application is suspected to be spam!
+Suspected spam: true
+<% else %>
+Suspected spam: false
 <% end %>


### PR DESCRIPTION
This PR fixes a couple of issues which were introduced when we rolled over to the new application page, due to some differences between the old and new notification emails that were sent out.

1. Made year display in a human readably form (ie. "2017" instead of "9006")
2. Always render the 'Suspected spam: <true|false>' field on emails to the team
3. Unique-ify email subjects to prevent threading