### PR TITLE
Add fallback fonts

### DIFF
--- a/frontend/src/containers/App/App.js
+++ b/frontend/src/containers/App/App.js
@@ -4,7 +4,7 @@ import config from '../../config'
 
 const styles = {
   height: '100%',
-  fontFamily: "'Open Sans', sans-serif"
+  fontFamily: "'Open Sans', -apple-system, BlinkMacSystemFont, 'Avenir Next', 'Helvetica Neue', Roboto, 'Segoe UI', sans-serif"
 }
 
 class App extends Component {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -6,5 +6,5 @@ body {
   margin: 0;
   padding: 0;
 
-  font-family: 'Open Sans', sans-serif;
+  font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Avenir Next', 'Helvetica Neue', Roboto, 'Segoe UI', sans-serif;
 }


### PR DESCRIPTION
Enhancement: If Open Sans fails to load (or content blockers/web filters are disabling Google Fonts), system fonts will be used instead.