### PR TITLE
Caching bundle install to improve build time

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     # Some people may choose to install gems into vendor/bundle/, which will
     # break Rubocop. Ignore it.
     - 'vendor/**/*'
+    - 'bundler_cache/**/*'
 
 # Don't do method length checks on database migrations. No need to make sure our
 # migrations fit any sort of method line limit goal.

--- a/circle.yml
+++ b/circle.yml
@@ -40,10 +40,12 @@ machine:
     DATABASE_URL: postgresql://ubuntu:@127.0.0.1:5432/circle_test
     CHANNELS_TO_CLEAR: ''
 dependencies:
+  cache_directories:
+    - "api/bundler_cache"
   override:
     - git submodule init
     - git submodule update
-    - cd api && bundle install
+    - cd api && bundle install --path bundler_cache
 test:
   override:
     - cd api && bundle exec rubocop


### PR DESCRIPTION
Requested on issue #151.

Running `bundle install` now saves the gems on a folder called `bundler_cache` on the same `api` folder during build. Next builds will restore this folder, resulting in saving time installing the gems.