### PR TITLE
Store geocoded address parts

### DIFF
--- a/api/app/models/club.rb
+++ b/api/app/models/club.rb
@@ -41,7 +41,14 @@ class Club < ApplicationRecord
 
   geocode_attrs address: :address,
                 latitude: :latitude,
-                longitude: :longitude
+                longitude: :longitude,
+                res_address: :parsed_address,
+                city: :parsed_city,
+                state: :parsed_state,
+                state_code: :parsed_state_code,
+                postal_code: :parsed_postal_code,
+                country: :parsed_country,
+                country_code: :parsed_country_code
 
   has_many :check_ins
   belongs_to :point_of_contact, class_name: 'Leader'

--- a/api/app/models/concerns/geocodeable.rb
+++ b/api/app/models/concerns/geocodeable.rb
@@ -2,23 +2,39 @@ module Geocodeable
   extend ActiveSupport::Concern
 
   module ClassMethods
-    attr_reader :geocodeable_address_attr, :geocodeable_lat_attr,
-                :geocodeable_lng_attr
+    attr_reader :geocodeable_address_attr,
+                :geocodeable_attr_mappings
 
     private
 
-    def geocode_attrs(address:, latitude:, longitude:)
-      @geocodeable_address_attr = address
-      @geocodeable_lat_attr = latitude
-      @geocodeable_lng_attr = longitude
+    def geocode_attrs(attrs = {})
+      address = @geocodeable_address_attr = attrs[:address]
+      attr_mappings = @geocodeable_attr_mappings = {
+        latitude: attrs[:latitude],
+        longitude: attrs[:longitude],
+        address: attrs[:res_address],
+        city: attrs[:city],
+        state: attrs[:state],
+        state_code: attrs[:state_code],
+        postal_code: attrs[:postal_code],
+        country: attrs[:country],
+        country_code: attrs[:country_code]
+      }
 
-      geocoded_by address,
-                  latitude: latitude,
-                  longitude: longitude
+      geocoded_by address do |obj, results|
+        geo = results.first
+
+        if geo
+          attr_mappings.each do |k, v|
+            geo_val = geo.send(k)
+
+            obj.send("#{v}=", geo_val)
+          end
+        end
+      end
 
       before_validation :geocode, if: (lambda do |obj|
-        obj.send(address).present? &&
-          obj.send("#{address}_changed?")
+        obj.send(address).present? && obj.send("#{address}_changed?")
       end)
     end
   end

--- a/api/app/models/leader.rb
+++ b/api/app/models/leader.rb
@@ -44,7 +44,14 @@ class Leader < ApplicationRecord
 
   geocode_attrs address: :address,
                 latitude: :latitude,
-                longitude: :longitude
+                longitude: :longitude,
+                res_address: :parsed_address,
+                city: :parsed_city,
+                state: :parsed_state,
+                state_code: :parsed_state_code,
+                postal_code: :parsed_postal_code,
+                country: :parsed_country,
+                country_code: :parsed_country_code
 
   before_validation :slack_update
 

--- a/api/db/migrate/20171024132156_add_geocodeable_address_parts.rb
+++ b/api/db/migrate/20171024132156_add_geocodeable_address_parts.rb
@@ -1,0 +1,23 @@
+class AddGeocodeableAddressParts < ActiveRecord::Migration[5.0]
+  def change
+    change_table :leaders do |t|
+      t.text :parsed_address
+      t.text :parsed_city
+      t.text :parsed_state
+      t.text :parsed_state_code
+      t.text :parsed_postal_code
+      t.text :parsed_country
+      t.text :parsed_country_code
+    end
+
+    change_table :clubs do |t|
+      t.text :parsed_address
+      t.text :parsed_city
+      t.text :parsed_state
+      t.text :parsed_state_code
+      t.text :parsed_postal_code
+      t.text :parsed_country
+      t.text :parsed_country_code
+    end
+  end
+end

--- a/api/db/migrate/20171024132156_add_geocodeable_address_parts.rb
+++ b/api/db/migrate/20171024132156_add_geocodeable_address_parts.rb
@@ -19,5 +19,12 @@ class AddGeocodeableAddressParts < ActiveRecord::Migration[5.0]
       t.text :parsed_country
       t.text :parsed_country_code
     end
+
+    # Regeocode clubs & leaders
+    [Club, Leader].each do |model|
+      model.find_each do |instance|
+        instance.geocode && instance.save
+      end
+    end
   end
 end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170926211959) do
+ActiveRecord::Schema.define(version: 20171024132156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,13 @@ ActiveRecord::Schema.define(version: 20170926211959) do
     t.text     "activation_date"
     t.text     "reason_of_death"
     t.datetime "time_of_death"
+    t.text     "parsed_address"
+    t.text     "parsed_city"
+    t.text     "parsed_state"
+    t.text     "parsed_state_code"
+    t.text     "parsed_postal_code"
+    t.text     "parsed_country"
+    t.text     "parsed_country_code"
     t.index ["point_of_contact_id"], name: "index_clubs_on_point_of_contact_id", using: :btree
     t.index ["streak_key"], name: "index_clubs_on_streak_key", using: :btree
   end
@@ -160,13 +167,20 @@ ActiveRecord::Schema.define(version: 20170926211959) do
     t.text     "address"
     t.decimal  "latitude"
     t.decimal  "longitude"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
     t.text     "streak_key"
     t.text     "notes"
     t.text     "slack_id"
     t.text     "slack_team_id"
     t.text     "stage_key"
+    t.text     "parsed_address"
+    t.text     "parsed_city"
+    t.text     "parsed_state"
+    t.text     "parsed_state_code"
+    t.text     "parsed_postal_code"
+    t.text     "parsed_country"
+    t.text     "parsed_country_code"
     t.index ["streak_key"], name: "index_leaders_on_streak_key", using: :btree
   end
 


### PR DESCRIPTION
This PR stores the address parts returned as part of geocoding, letting us easily query for things like # of countries our clubs are in.