### PR TITLE
Add picture submission link to submit_check_in

### DIFF
--- a/api/lib/data/copy/check_in.yml
+++ b/api/lib/data/copy/check_in.yml
@@ -100,7 +100,7 @@ submit_confirmation:
     restart:
         action_result: ":leftwards_arrow_with_hook: You want to start over"
 
-submit_check_in: Thanks, I'll pass that on to the Hack Club team! Hope you had a happy hack-lo-ween :jack_o_lantern::ghost::jack_o_lantern:!
+submit_check_in: Thanks, I'll pass that on to the Hack Club team! If you have taken any pictures during your meeting, please submit them to http://hack.af/WTd7qh, and they might get featured on our Twitter!
 
 follow_ups:
     first: "Hey! Just wanted to follow-up on this. :wink:"


### PR DESCRIPTION
Added the link as a short link under hack.af . If possible, a hackclub.com/dropbox or dropbox.hackclub.com link would be better.