### PR TITLE
Allow retrieving just submitted applications

### DIFF
--- a/api/app/controllers/v1/new_club_applications_controller.rb
+++ b/api/app/controllers/v1/new_club_applications_controller.rb
@@ -7,7 +7,14 @@ module V1
     # All applications
     def full_index
       return render_access_denied unless @user.admin?
-      render_success NewClubApplication.all.includes(leader_profiles: [:user])
+
+      apps = if params[:submitted]
+               NewClubApplication.submitted.all
+             else
+               NewClubApplication.all
+             end
+
+      render_success apps.includes(leader_profiles: [:user])
     end
 
     # Applications for a specific user

--- a/api/app/models/new_club_application.rb
+++ b/api/app/models/new_club_application.rb
@@ -3,6 +3,8 @@
 class NewClubApplication < ApplicationRecord
   include Geocodeable
 
+  scope :submitted, -> { where.not(submitted_at: nil) }
+
   validate :point_of_contact_is_associated
 
   has_many :leader_profiles

--- a/api/spec/factories/new_club_applications.rb
+++ b/api/spec/factories/new_club_applications.rb
@@ -46,6 +46,16 @@ FactoryBot.define do
                     new_club_application: application)
 
         application.point_of_contact = application.users.first
+        application.save
+      end
+    end
+
+    factory :submitted_new_club_application,
+            parent: :completed_new_club_application do
+
+      after(:create) do |application|
+        application.submitted_at = Time.current
+        application.save
       end
     end
   end


### PR DESCRIPTION
Usage: `GET /v1/new_club_applications?submitted=true`

cc @MaxWofford 